### PR TITLE
Fetch cart cookies with js-cookie lib instead of relying on Commerce.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@chec/commerce.js": "^2.2.0",
     "create-shared-react-context": "^1.0.3",
+    "js-cookie": "^2.2.1",
     "lodash.get": "^4.4.2",
     "swr": "^0.4.0"
   },

--- a/src/cart/useActiveCartId.js
+++ b/src/cart/useActiveCartId.js
@@ -1,10 +1,12 @@
 import useCommerce from '../useCommerce';
+import Cookie from 'js-cookie';
 
 export default function useActiveCartId() {
   const commerce = useCommerce();
 
   if (commerce && commerce.cart) {
-    return commerce.cart.id();
+    // Fallback to accessing the cookie ourselves, as the implementation provided by Commerce.js itself is a bit flakey
+    return commerce.cart.id() || Cookie.get('commercejs_cart_id');
   }
 
   return null;

--- a/src/cart/useCart.js
+++ b/src/cart/useCart.js
@@ -1,9 +1,14 @@
 import useSWR from 'swr';
 import useCommerceSwrFetcher from '../useCommerceSwrFetcher';
+import useActiveCartId from './useActiveCartId';
 
 export default function useCart(cartId) {
   const fetcher = useCommerceSwrFetcher();
-  const { data, error } = useSWR(['cart.retrieve', cartId], fetcher);
+  const defaultCartId = useActiveCartId();
+
+  // Rely on our own tracking of active cart ID above the logic in `cart.retrieve` itself. See comments in
+  // `useActiveCartId` for more details
+  const { data, error } = useSWR(['cart.retrieve', cartId || defaultCartId], fetcher);
 
   if (error) {
     throw error;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2014,6 +2014,11 @@ jest-worker@^26.2.1:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
@kvisca I think this resolves the issues with carts on Beacon. Commerce.js doesn't correctly access cookies in a cross-platform way, which I think is the cause of carts failing while rendering on the server.