### PR TITLE
Remove setServerErrors argument from capture hooks, remove catch handler from useCapture hook

### DIFF
--- a/src/checkout/useCapture.js
+++ b/src/checkout/useCapture.js
@@ -6,28 +6,9 @@ export default function useCapture() {
   const commerce = useCommerce();
   const { checkout, createCheckout } = useContext(CheckoutContext);
 
-  return (detail, setServerErrors) => commerce.checkout.capture(checkout.id, detail)
+  return (detail) => commerce.checkout.capture(checkout.id, detail)
     .then((response) => {
       createCheckout();
       return response;
-    })
-    .catch((error) => {
-      // It might be nested objects referencing specific fields,
-      // and an array of error messages
-      if (error.statusCode === 422 && typeof error?.data?.error?.errors !== 'undefined') {
-        const errors = Object.values(error.data.error.errors).reduce((acc, value) => {
-          value.map((error) => acc.push(error));
-          return acc;
-        })
-        setServerErrors(errors);
-        return;
-      }
-      // Sometimes it will be a flat string error eg. 402 errors
-      if (typeof error.data.error.message !== 'undefined') {
-        setServerErrors([error.data.error.message]);
-        return;
-      }
-      // Some other kind of exception, e.g. server error
-      setServerErrors(['Something went wrong, please try again.']);
     });
 }

--- a/src/checkout/useCaptureWithStripe.js
+++ b/src/checkout/useCaptureWithStripe.js
@@ -12,7 +12,7 @@ export default function useCaptureWithStripe() {
     }
   })()
 
-  return useCallback(async (detail, setServerErrors) => {
+  return useCallback(async (detail) => {
     const card = elements.getElement(CardElement);
     const paymentMethodResponse = await stripe.createPaymentMethod({ type: 'card', card });
 
@@ -29,7 +29,7 @@ export default function useCaptureWithStripe() {
             payment_method_id: paymentMethodResponse.paymentMethod.id,
           },
         },
-      }, setServerErrors);
+      });
     } catch (response) {
       // Check if we should rethrow the error if it's not related to 3DS issues
       if (response.statusCode !== 402 || response.data.error.type !== 'requires_verification') {
@@ -45,7 +45,7 @@ export default function useCaptureWithStripe() {
             payment_intent_id: cardActionResult.paymentIntent.id,
           },
         },
-      }, setServerErrors);
+      });
     }
   }, [stripe, elements])
 }


### PR DESCRIPTION
The catch handler here, and the setServerErrors stuff should be in the clients that use this library rather than in these hooks. The fact that useCapture doesn't return the error it catches means that SCA with Stripe is broken. This will fix that, and I will port the catch handler logic into our templates shortly.
