### PR TITLE
Refactor useLocationFromIp to use state and side-effects instead of a callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The following hooks are available for use within a checkout, and are all exporte
 | `useCheckVariant()` | Checks that the provided variant ID and option ID is valid for the provided line item ID. See [check variant](https://commercejs.com/docs/api/#check-variant) in the docs. |
 | `useConditionals()` | Provides the "conditionals" attribute from the checkout, indicating what conditional flags apply for the current checkout |
 | `useLineItems()` | Provides the line items in the checkout |
-| `useLocationFromIp()` | Provides geographic information about the user from their IP address. See [get buyer's location from IP](https://commercejs.com/docs/api/#get-buyer-039-s-location-from-ip) in the docs. |
+| `useLocationFromIp()` | Provides geographic information about the user from their IP address. Returns the discovered location information, or null if the checkout is not available. See [get buyer's location from IP](https://commercejs.com/docs/api/#get-buyer-039-s-location-from-ip) in the docs for more information. |
 | `useShippingCountries()` | Provides the countries that are eligible for shipping based on the product selection in the checkout |
 | `useShippingOptions(country, region)` | Provides the shipping options that can be selected for the given country (and region if provided) based on the product selection in the checkout |
 | `useShippingSubdivisions(countryCode)` | Provides subdivisions of the given country code |


### PR DESCRIPTION
This means you can do something like:

```js
const location = useLocationFromIp();

useEffect(() => {
  if (!location) {
    return;
  }

  const { region_code } = location;

  setSubdivision(region_code);
}, [location]);
```